### PR TITLE
Add Dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "master"
+- package-ecosystem: yarn
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "master"


### PR DESCRIPTION
Dependabot will submit pull requests
when packages get new versions released.
This configuration is to keep the Github
actions and the yarn packages up to date.

Link to Dependabot documentation:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot